### PR TITLE
Added basic support of itegration tests via llvm-lit.

### DIFF
--- a/test/binder.m
+++ b/test/binder.m
@@ -1,3 +1,5 @@
+// RUN: %key_path_validator_cc1 -verify %s
+
 #import <Foundation/Foundation.h>
 
 @interface Bindable : NSObject
@@ -11,14 +13,15 @@ static void testFn(void)
 {
     Bindable *obj;
     NSTimer *t = nil;
-    [obj bindToModel:t keyPath:@"self.fireDate" change:^{}];
-    [obj bindToModel:t keyPath:@"fireDate.timeIntervalSinceNow" change:^{}];
-    [obj bindToModel:[NSRunLoop mainRunLoop] keyPath:@"currentMode.length.foo" change:^{}];
-    [obj bindToModel:[NSRunLoop mainRunLoop] keyPath:@"currentMode.length.integerValue" change:^{}];
-    [obj bindToModel:t keyPath:@"doesNotExst" change:^{}];
+    [obj bindToModel:t keyPath:@"self.fireDate" change:^{}]; // no-warning
+    [obj bindToModel:t keyPath:@"fireDate.timeIntervalSinceNow" change:^{}]; // no-warning
+    [obj bindToModel:[NSRunLoop mainRunLoop] keyPath:@"currentMode.length.foo" change:^{}]; // expected-warning {{key 'foo' not found on type NSNumber}}
+    [obj bindToModel:[NSRunLoop mainRunLoop] keyPath:@"currentMode.length.integerValue" change:^{}]; // no-warning
+    [obj bindToModel:t keyPath:@"doesNotExst" change:^{}]; // expected-warning {{key 'doesNotExst' not found on type NSTimer}}
 
     id idObj;
-    [obj bindToModel:idObj keyPath:@"foo" change:^{}];
+    [obj bindToModel:idObj keyPath:@"foo" change:^{}]; // no-warning
 
-    [obj bindToModels:@[t, idObj] keyPaths:@[@[@"fireDate", @"doesNotExist"], @[@"doesNotExist"]] change:^{}];
+    [obj bindToModels:@[t, idObj] keyPaths:@[@[@"fireDate", @"doesNotExist"], @[@"doesNotExist"]] change:^{}]; // expected-warning {{key 'doesNotExist' not found on type NSTimer}}
 }
+

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1,0 +1,30 @@
+import subprocess
+import lit.formats
+
+config.name = "KeyPathValidator"
+config.test_format = lit.formats.ShTest(False)
+
+clang_path = "your path to clang binary"
+plugin_path = "your path to KeyPathValidatorPlugin.dylib"
+
+config.clang = clang_path
+
+def getClangBuiltinIncludeDir(clang):
+    cmd = subprocess.Popen([clang, '-print-file-name=include'],
+                           stdout=subprocess.PIPE)
+    if not cmd.stdout:
+      lit.fatal("Couldn't find the include dir for Clang ('%s')" % clang)
+    return cmd.stdout.read().strip()
+
+config.substitutions.append( ('%clang_cc1', '%s -cc1 -internal-isystem %s'
+                              % (config.clang, getClangBuiltinIncludeDir(config.clang))) )
+
+key_path_validator_plugin =  ("""%s -cc1 -internal-isystem %s 
+             -load %s
+             -plugin validate-key-paths 
+             -fblocks -fsyntax-only -fobjc-arc
+             """ % (config.clang, getClangBuiltinIncludeDir(config.clang), plugin_path) )
+
+config.substitutions.append(('%key_path_validator_cc1', key_path_validator_plugin))
+
+


### PR DESCRIPTION
This is just kind of draft.
Probably, it's not the best and/or correct way, but it works, almost :smile: 
To make it working you should put some efforts:
1. Specify path to your built clang at `lit.cfg:7`
2. Specify path to your built plugin (dylib) at `lit.cfg:8`

Now you can run tests with a simple command

``` bash
path_to_bin/llvm-lit test/basic.m
```

Expected output:

```
-- Testing: 1 tests, 1 threads --
PASS: KeyPathValidator :: basic.m (1 of 1)
Testing Time: 3.52s
  Expected Passes    : 1
```

Closes #1.
